### PR TITLE
Making nuget install binaries to ${project}\libs

### DIFF
--- a/AutoImplement.nuspec
+++ b/AutoImplement.nuspec
@@ -22,7 +22,7 @@
     <copyright>Copyright 2018</copyright>
   </metadata>
   <files>
-    <file src="artifacts\AutoImplement\bin\Release\AutoImplement.exe" target="" />
+    <file src="artifacts\AutoImplement\bin\Release\AutoImplement.exe" target="content\libs" />
     <file src="artifacts\System.Delegation\bin\Release\System.Delegation.dll" target="lib" />
     <file src="artifacts\System.Delegation\bin\Release\System.Delegation.xml" target="lib" />
   </files>


### PR DESCRIPTION
Specifying the destination of the files on install so that a pre-build step can become something like:
`$(ProjectDir)libs\AutoImplement`
without any extra work.