### PR TITLE
bugfix: should be able to create implementation for interfaces where a

### DIFF
--- a/src/AutoImplement.Tests/InterfaceCompileTests.cs
+++ b/src/AutoImplement.Tests/InterfaceCompileTests.cs
@@ -66,6 +66,9 @@ namespace HavenSoft.AutoImplement.Tests {
       [Fact]
       public void CanGenerateFromInterfaceWithBaseInterfaceEvents() => AssertCompile(typeof(IInterfaceWithBaseEventInterface));
 
+      [Fact]
+      public void CanGenerateFromInterfaceThatOverridesProperty() => AssertCompile(typeof(IInterfaceThatOverridesProperty));
+
       private static void AssertCompile(Type interfaceType) {
          Program.GenerateImplementations(ThisAssembly, interfaceType.Name);
 

--- a/src/AutoImplement.Tests/TestInterfaces.cs
+++ b/src/AutoImplement.Tests/TestInterfaces.cs
@@ -66,4 +66,9 @@ namespace HavenSoft.AutoImplement.Tests {
    public interface IInterfaceWithBaseEventInterface : INotifyPropertyChanged {
       ICommand SomeProperty { get; }
    }
+
+   public interface IInterfaceThatOverridesProperty : IReadOnlyList<int> {
+      new int this[int index] { get; set; }
+      new int Count { get; set; }
+   }
 }

--- a/src/AutoImplement/DecoratorBuilder.cs
+++ b/src/AutoImplement/DecoratorBuilder.cs
@@ -9,6 +9,7 @@ namespace HavenSoft.AutoImplement {
    /// </summary>
    public class DecoratorBuilder : IPatternBuilder {
       private readonly List<string> implementedMethods = new List<string>();
+      private readonly List<string> implementedProperties = new List<string>();
 
       private string innerObject;
 
@@ -143,16 +144,50 @@ namespace HavenSoft.AutoImplement {
       /// }
       /// </example>
       public void AppendProperty(PropertyInfo info, MemberMetadata property) {
+         // Use an explicit implementation only if the signature has already been used
+         // example: an interface may implement both IList<T> and IReadOnlyList<T>, which both provide this[int]
+         // since expicit implementation can't be virtual, have the explicit one call the normal one.
+         // In the case of IList<T> and IReadOnlyList<T>, this is correct.
+         // Hopefully there aren't too many interfaces that do this, cuz it's WEIRD.
+         // When it does happen, hopefully the creator of the child interface wants the child to behave as the parent...
+         // in which case this is the correct implementation.
+         if (implementedProperties.Contains(property.Name)) {
+            writer.Write($"{property.ReturnType} {property.DeclaringType}.{property.Name}");
+            using (writer.Scope) {
+               if (info.GetMethod != null) writer.Write($"get {{ return this.{property.Name}; }}");
+               if (info.SetMethod != null) writer.Write($"set {{ this.{property.Name} = value; }}");
+            }
+            return;
+         }
+
          writer.Write($"public virtual {property.ReturnType} {property.Name}");
          AppendPropertyCommon(info, property, $"{innerObject}.{info.Name}");
+         implementedProperties.Add(property.Name);
       }
 
       /// <remarks>
       /// For decorators, Item properties are much the same as normal propreties.
       /// </remarks>
       public void AppendItemProperty(PropertyInfo info, MemberMetadata property) {
+         // Use an explicit implementation only if the signature has already been used
+         // example: an interface may implement both IList<T> and IReadOnlyList<T>, which both provide this[int]
+         // since expicit implementation can't be virtual, have the explicit one call the normal one.
+         // In the case of IList<T> and IReadOnlyList<T>, this is correct.
+         // Hopefully there aren't too many interfaces that do this, cuz it's WEIRD.
+         // When it does happen, hopefully the creator of the child interface wants the child to behave as the parent...
+         // in which case this is the correct implementation.
+         if (implementedProperties.Contains(property.Name)) {
+            writer.Write($"{property.ReturnType} {property.DeclaringType}.this[{property.ParameterTypesAndNames}]");
+            using (writer.Scope) {
+               if (info.GetMethod != null) writer.Write($"get {{ return this[{property.ParameterNames}]; }}");
+               if (info.SetMethod != null) writer.Write($"set {{ this[{property.ParameterNames}] = value; }}");
+            }
+            return;
+         }
+
          writer.Write($"public virtual {property.ReturnType} this[{property.ParameterTypesAndNames}]");
          AppendPropertyCommon(info, property, $"{innerObject}[{property.ParameterNames}]");
+         implementedProperties.Add(property.Name);
       }
 
       public void BuildCompleted() { }


### PR DESCRIPTION
  child interface adds extra getter/setter to a property from a base
  interface. Example: If an interface implemented both
  IList<> were to implement IReadOnlyList<>.